### PR TITLE
Fix missing newline in robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -3,4 +3,4 @@ Allow: /
 Sitemap: https://vijayasaiphotoframes.com/sitemap.xml
 Disallow: /cgi-bin/
 Disallow: /tmp/
-Disallow: /private/ 
+Disallow: /private/


### PR DESCRIPTION
## Summary
- add a newline to the last line of `robots.txt`

## Testing
- `cat -A robots.txt`


------
https://chatgpt.com/codex/tasks/task_e_6843152dd52c8330a15e28d818ebf2f4