### PR TITLE
Add 404 page and cache support

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="robots" content="noindex">
+  <link rel="canonical" href="https://vijayasaiphotoframes.com/">
+  <title>Page Not Found - Vijayasai Photo Frames</title>
+  <meta name="description" content="The page you are looking for could not be found.">
+  <meta property="og:title" content="Page Not Found - Vijayasai Photo Frames & Laminations">
+  <meta property="og:description" content="The requested page could not be found.">
+  <meta property="og:url" content="https://vijayasaiphotoframes.com/404.html">
+  <meta property="og:type" content="website">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.1.3/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <div class="container text-center mt-5">
+    <h1>404 - Page Not Found</h1>
+    <p>Sorry, the page you were looking for doesn't exist.</p>
+    <a href="index.html" class="btn btn-primary mt-3">Go Home</a>
+  </div>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -125,4 +125,9 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
     });
-}); 
+
+    // Register service worker for offline support
+    if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('/service-worker.js');
+    }
+});

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,27 @@
+const CACHE_NAME = 'vsl-cache-v1';
+const OFFLINE_URL = '/404.html';
+const URLS_TO_CACHE = [
+  '/',
+  '/index.html',
+  OFFLINE_URL,
+  '/css/style.css',
+  '/js/main.js'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match(OFFLINE_URL))
+    );
+    return;
+  }
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- create a dedicated `404.html` page with noindex and canonical tags
- register a service worker in the front-end script
- add new `service-worker.js` that caches the offline page

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843251e551c8330a0503c3b77c9f2e1