### PR TITLE
Disable page scroll during initial loader

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1135,6 +1135,11 @@ html, body {
     }
 }
 
+body.no-scroll {
+    overflow: hidden;
+    height: 100%;
+}
+
 /* Loading Animation Styles */
 .page-loader {
     position: fixed;

--- a/js/main.js
+++ b/js/main.js
@@ -12,12 +12,17 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Loading animation
     const loader = document.querySelector('.page-loader');
+    const body = document.body;
+
     if (loader) {
+        body.classList.add('no-scroll');
+
         window.addEventListener('load', function() {
             setTimeout(function() {
                 loader.classList.add('fade-out');
                 setTimeout(function() {
                     loader.style.display = 'none';
+                    body.classList.remove('no-scroll');
                 }, 500);
             }, 1000);
         });

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -50,4 +50,15 @@ describe('Animation and loader behaviors', () => {
     jest.advanceTimersByTime(1000);
     expect(loader.classList.contains('fade-out')).toBe(true);
   });
+
+  test('scroll is disabled during load and enabled after loader hides', () => {
+    const loader = document.querySelector('.page-loader');
+    expect(document.body.classList.contains('no-scroll')).toBe(true);
+
+    window.dispatchEvent(new Event('load'));
+    jest.advanceTimersByTime(1500);
+
+    expect(loader.style.display).toBe('none');
+    expect(document.body.classList.contains('no-scroll')).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent scrolling while the loading screen is visible
- re-enable scrolling once the loader fades out
- test the no-scroll behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850848e756883309d0d4bd16308bb3e