### PR TITLE
Ensure no-scroll class applies to html element

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1135,6 +1135,7 @@ html, body {
     }
 }
 
+html.no-scroll,
 body.no-scroll {
     overflow: hidden;
     height: 100%;

--- a/js/main.js
+++ b/js/main.js
@@ -12,9 +12,11 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Loading animation
     const loader = document.querySelector('.page-loader');
+    const html = document.documentElement;
     const body = document.body;
 
     if (loader) {
+        html.classList.add('no-scroll');
         body.classList.add('no-scroll');
 
         window.addEventListener('load', function() {
@@ -22,6 +24,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 loader.classList.add('fade-out');
                 setTimeout(function() {
                     loader.style.display = 'none';
+                    html.classList.remove('no-scroll');
                     body.classList.remove('no-scroll');
                 }, 500);
             }, 1000);

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -54,11 +54,13 @@ describe('Animation and loader behaviors', () => {
   test('scroll is disabled during load and enabled after loader hides', () => {
     const loader = document.querySelector('.page-loader');
     expect(document.body.classList.contains('no-scroll')).toBe(true);
+    expect(document.documentElement.classList.contains('no-scroll')).toBe(true);
 
     window.dispatchEvent(new Event('load'));
     jest.advanceTimersByTime(1500);
 
     expect(loader.style.display).toBe('none');
     expect(document.body.classList.contains('no-scroll')).toBe(false);
+    expect(document.documentElement.classList.contains('no-scroll')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- prevent scrolling by applying `.no-scroll` to both `html` and `body`
- sync loader script with new `.no-scroll` rule
- update tests for `document.documentElement`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685086d0fe388330836ac4e88c9bbca1