### PR TITLE
Fix parseInt call base

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -106,7 +106,7 @@ document.addEventListener('DOMContentLoaded', function() {
         entries.forEach(entry => {
             if (entry.isIntersecting) {
                 const counter = entry.target;
-                const target = parseInt(counter.getAttribute('data-target'));
+                const target = parseInt(counter.getAttribute('data-target'), 10);
                 animateCounter(counter, target);
                 observer.unobserve(counter);
             }


### PR DESCRIPTION
## Summary
- specify radix when reading counter target

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68509320220c8330ba0efb3a341aac62